### PR TITLE
first_添加getContentPreview

### DIFF
--- a/frontend/src/views/manager2.vue
+++ b/frontend/src/views/manager2.vue
@@ -1855,6 +1855,11 @@ export default {
     },
 
     // 公告管理相关方法
+    // 公告内容预览方法
+    getContentPreview(content) {
+      if (!content) return '';
+      return content.length > 50 ? content.substring(0, 50) + '...' : content;
+    },
     async fetchAnnouncements() {
       const token = localStorage.getItem('token');
       if (!token) {


### PR DESCRIPTION
## 修改类型
- [ ] 新功能
- [X] Bug修复
- [ ] 文档更新
- [ ] 其他

## 修改目的
可以使前端抓取后端的数据

## 修改内容
在js的methods中补充了getContentPreview （截断公告内容的辅助方法）到公告管理获取上端

## 相关Issue
Closes #61 